### PR TITLE
Don't use SSH if the destination is 127.0.0.1

### DIFF
--- a/zrep
+++ b/zrep
@@ -271,6 +271,9 @@ zrep_ssh(){
 		localhost|$Z_LOCAL_HOST)
 			ssh_cmd=""
 			;;
+		127.0.0.1|$Z_LOCAL_HOST)
+			ssh_cmd=""
+			;;
 		*)
 			ssh_cmd="$SSH $1"
 			;;


### PR DESCRIPTION
Bypass SSH if you are using 127.0.0.1 as the host as well as localhost.