### PR TITLE
Fixed Z_HAS_O on SmartOS

### DIFF
--- a/zrep
+++ b/zrep
@@ -190,7 +190,11 @@ if ((Z_HAS_X)) ; then
 	# until I find somewhere it isnt...
 	Z_HAS_O=1  # can recv use -o option
 else
-	Z_HAS_O=0
+	if grep 'receive.*-o' $zrep_checkfile >/dev/null ;then
+		Z_HAS_O=1
+	else
+		Z_HAS_O=0
+	fi
 fi
 rm $zrep_checkfile
 

--- a/zrep_vars
+++ b/zrep_vars
@@ -184,7 +184,11 @@ if ((Z_HAS_X)) ; then
 	# until I find somewhere it isnt...
 	Z_HAS_O=1  # can recv use -o option
 else
-	Z_HAS_O=0
+	if grep 'receive.*-o' $zrep_checkfile >/dev/null ;then
+		Z_HAS_O=1
+	else
+		Z_HAS_O=0
+	fi
 fi
 rm $zrep_checkfile
 


### PR DESCRIPTION
On SmartOS (20170119T014200Z), there is no `recv -x` support, but there is `recv -o` support. Due to that, zvols can't be automatically initialised (I saw source code for initialize and don't know why).

FYI: This is how zfs help on SmartOS looks like:
```
missing command
usage: zfs command args ...
where 'command' is one of the following:

        create [-p] [-o property=value] ... <filesystem>
        create [-ps] [-b blocksize] [-o property=value] ... -V <size> <volume>
        destroy [-fnpRrv] <filesystem|volume>
        destroy [-dnpRrv] <filesystem|volume>@<snap>[%<snap>][,...]
        destroy <filesystem|volume>#<bookmark>

        snapshot [-r] [-o property=value] ... <filesystem|volume>@<snap> ...
        rollback [-rRf] <snapshot>
        clone [-p] [-o property=value] ... <snapshot> <filesystem|volume>
        promote <clone-filesystem>
        rename [-f] <filesystem|volume|snapshot> <filesystem|volume|snapshot>
        rename [-f] -p <filesystem|volume> <filesystem|volume>
        rename -r <snapshot> <snapshot>
        bookmark <snapshot> <bookmark>

        list [-Hp] [-r|-d max] [-o property[,...]] [-s property]...
            [-S property]... [-t type[,...]] [filesystem|volume|snapshot] ...

        set <property=value> ... <filesystem|volume|snapshot> ...
        get [-crHp] [-d max] [-o "all" | field[,...]]
            [-t type[,...]] [-s source[,...]]
            <"all" | property[,...]> [filesystem|volume|snapshot|bookmark] ...
        inherit [-rS] <property> <filesystem|volume|snapshot> ...
        upgrade [-v]
        upgrade [-r] [-V version] <-a | filesystem ...>
        userspace [-Hinp] [-o field[,...]] [-s field] ...
            [-S field] ... [-t type[,...]] <filesystem|snapshot>
        groupspace [-Hinp] [-o field[,...]] [-s field] ...
            [-S field] ... [-t type[,...]] <filesystem|snapshot>

        mount
        mount [-vO] [-o opts] <-a | filesystem>
        unmount [-f] <-a | filesystem|mountpoint>
        share <-a | filesystem>
        unshare <-a | filesystem|mountpoint>

        send [-DnPpRvLec] [-[iI] snapshot] <snapshot>
        send [-Le] [-i snapshot|bookmark] <filesystem|volume|snapshot>
        send [-nvPe] -t <receive_resume_token>
        receive [-vnsFu] <filesystem|volume|snapshot>
        receive [-vnsFu] [-o origin=<snapshot>] [-d | -e] <filesystem>
        receive -A <filesystem|volume>

        allow <filesystem|volume>
        allow [-ldug] <"everyone"|user|group>[,...] <perm|@setname>[,...]
            <filesystem|volume>
        allow [-ld] -e <perm|@setname>[,...] <filesystem|volume>
        allow -c <perm|@setname>[,...] <filesystem|volume>
        allow -s @setname <perm|@setname>[,...] <filesystem|volume>

        unallow [-rldug] <"everyone"|user|group>[,...]
            [<perm|@setname>[,...]] <filesystem|volume>
        unallow [-rld] -e [<perm|@setname>[,...]] <filesystem|volume>
        unallow [-r] -c [<perm|@setname>[,...]] <filesystem|volume>
        unallow [-r] -s @setname [<perm|@setname>[,...]] <filesystem|volume>

        hold [-r] <tag> <snapshot> ...
        holds [-r] <snapshot> ...
        release [-r] <tag> <snapshot> ...
        diff [-FHt] <snapshot> [snapshot|filesystem]

Each dataset is of the form: pool/[dataset/]*dataset[@name]

For the property list, run: zfs set|get

For the delegated permission list, run: zfs allow|unallow
```