### PR TITLE
fixed overly aggressive use of -s local in zrep_takeover

### DIFF
--- a/zrep
+++ b/zrep
@@ -79,6 +79,13 @@ ZREPTAG=${ZREPTAG:-zrep}
 # If you dont have /usr/perl5, this wont hurt you so just ignore it.
 PERL_BIN=${PERL_BIN:-/usr/perl5/bin}
 
+# If you wish to add a suffix to the detected local hostname, add it here.
+# This is especially useful if you want to run the replication over a
+# second network interface with possibly even a dedicated switch.
+# You could then use a separate local subnet and add e.g. all hostnames
+# with an "-int" suffix to DNS.
+#Z_LOCAL_HOST_SUFFIX=-int
+
 
 
 #########################################################################
@@ -117,6 +124,7 @@ if [[ "$ZREP_SRC_HOST" != "" ]] ; then
 else
 	Z_LOCAL_HOST=`uname -n`
 	Z_LOCAL_HOST=${Z_LOCAL_HOST%%.*}
+	Z_LOCAL_HOST="${Z_LOCAL_HOST}${Z_LOCAL_HOST_SUFFIX:}"
 fi
 
 if [[ "$ZREP_R" == "-R" ]] ; then

--- a/zrep
+++ b/zrep
@@ -1917,8 +1917,8 @@ zrep_takeover(){
 	fi
 
 
-	remotehost=`$ZFSGETLVAL ${ZREPTAG}:src-host $fs`
-	remotefs=`$ZFSGETLVAL ${ZREPTAG}:src-fs $fs`
+	remotehost=`zfs get -H -o value ${ZREPTAG}:src-host $fs`
+	remotefs=`zfs get -H -o value ${ZREPTAG}:src-fs $fs`
 
 
 	if (( local == 0 )) ; then

--- a/zrep
+++ b/zrep
@@ -1368,13 +1368,20 @@ _sync(){
 
 	# other than zrep_init, this should be the ONLY place we do a send
 	#   Sigh. but now we also do in _refreshpull
+	#
+	# As a workaround for the "destination ... has been modified" problem, we are
+	# using 'zfs recv -F' in order to get a clean state on the receiving side. See:
+	# http://list.zfsonlinux.org/pipermail/zfs-discuss/2015-June/022565.html
+	# https://github.com/zfsonlinux/zfs/issues/3490
+	# This might be a ZFS on Linux only issue, though.
+	#
 	if [[ "$BBCP" != "" ]] ; then
 	        SENDCMD="zfs send ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap"
 		$BBCP -N io "$SENDCMD" \
-		   "$desthost:zfs recv $destfs"
+		   "$desthost:zfs recv -F $destfs"
 	else
 		eval zfs send ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap ${Z_F_OUT} | 
-		   zrep_ssh $desthost "${Z_F_IN} zfs recv $destfs"
+		   zrep_ssh $desthost "${Z_F_IN} zfs recv -F $destfs"
 	fi
 
 	# I rename this to _unsent rather than just delete, in case people are using zrep

--- a/zrep
+++ b/zrep
@@ -564,7 +564,7 @@ list_verbose(){
 		# match these 'source' types. So "grep zrep:" is not
 		# neccessary. Although we may pick up other user-set values,
 		# but that is not neccessarily a bad thing
-	zfs get -H -o property,value -s $PROPTYPES all $1
+	zfs get -H -o property,value -s $PROPTYPES all $1 | sort
 	print "last snapshot synced: `getlastsnapsent $1`"
 
 }

--- a/zrep
+++ b/zrep
@@ -950,6 +950,7 @@ setfsconfigs(){
 	zfs set ${ZREPTAG}:dest-fs=$destfs		$fsname
 	zfs set ${ZREPTAG}:dest-host=$desthost		$fsname
 	zfs set ${ZREPTAG}:savecount=$Z_SAVE_COUNT	$fsname
+	zfs set ${ZREPTAG}:orig-host=$Z_LOCAL_HOST	$fsname
 }
 
 
@@ -1069,7 +1070,8 @@ zrep_init(){
 		zrep_ssh $desthost zfs set ${ZREPTAG}:src-host=$Z_LOCAL_HOST $destfs
 		zrep_ssh $desthost zfs set ${ZREPTAG}:dest-fs=$destfs $destfs
 		zrep_ssh $desthost zfs set ${ZREPTAG}:dest-host=$desthost $destfs
-		zrep_ssh $desthost zfs set ${ZREPTAG}:savecount=$Z_SAVE_COUNT	$destfs
+		zrep_ssh $desthost zfs set ${ZREPTAG}:savecount=$Z_SAVE_COUNT $destfs
+		zrep_ssh $desthost zfs set ${ZREPTAG}:orig-host=$Z_LOCAL_HOST $destfs
 
 	fi
 

--- a/zrep
+++ b/zrep
@@ -873,7 +873,7 @@ _clear(){
 clearquit(){
 	remhost=`$ZFSGETVAL ${ZREPTAG}:dest-host $1`
 	remfs=`$ZFSGETVAL ${ZREPTAG}:dest-fs $1`
-	if [[ $? -eq 0 ]] && [[ "$remhost" != "" ]] && [[ "$remfs" != "" ]]; then
+	if [[ $? -eq 0 ]] && [[ "$remhost" != "-" ]] && [[ "$remfs" != "-" ]]; then
 		zrep_ssh $remhost zfs destroy -r $remfs
 	fi
 
@@ -958,7 +958,7 @@ zrep_init(){
 
 	#sanity checks
 	check="`$ZFSGETVAL ${ZREPTAG}:dest-fs $srcfs`"
-	if [[ "$check" != "" ]] ; then
+	if [[ "$check" != "-" ]] ; then
 		print "$srcfs is at least partially configured by zrep"
 		check="`$ZFSGETLVAL ${ZREPTAG}:master $srcfs`"
 		if [[ "$check" != "" ]] ; then
@@ -1412,7 +1412,7 @@ zrep_synconly(){
 
 	desthost=`$ZFSGETVAL ${ZREPTAG}:dest-host $srcfs`
 	destfs=`$ZFSGETVAL ${ZREPTAG}:dest-fs $srcfs`
-	if [[ $? -ne 0 ]] || [[ "$desthost" == "" ]] || [[ "$destfs" == "" ]];
+	if [[ $? -ne 0 ]] || [[ "$desthost" == "-" ]] || [[ "$destfs" == "-" ]];
 	then
 		zrep_errquit Problem getting zrep properties for fs $srcfs
 	fi
@@ -1473,7 +1473,7 @@ zrep_sync(){
 
 	desthost=`$ZFSGETVAL ${ZREPTAG}:dest-host $srcfs`
 	destfs=`$ZFSGETVAL ${ZREPTAG}:dest-fs $srcfs`
-	if [[ $? -ne 0 ]] || [[ "$desthost" == "" ]] || [[ "$destfs" == "" ]];
+	if [[ $? -ne 0 ]] || [[ "$desthost" == "-" ]] || [[ "$destfs" == "-" ]];
 	then
 		zrep_errquit Problem getting zrep properties for fs $srcfs
 	fi

--- a/zrep_failover
+++ b/zrep_failover
@@ -117,8 +117,8 @@ zrep_takeover(){
 	fi
 
 
-	remotehost=`$ZFSGETLVAL ${ZREPTAG}:src-host $fs`
-	remotefs=`$ZFSGETLVAL ${ZREPTAG}:src-fs $fs`
+	remotehost=`zfs get -H -o value ${ZREPTAG}:src-host $fs`
+	remotefs=`zfs get -H -o value ${ZREPTAG}:src-fs $fs`
 
 
 	if (( local == 0 )) ; then

--- a/zrep_snap
+++ b/zrep_snap
@@ -277,6 +277,7 @@ setfsconfigs(){
 	zfs set ${ZREPTAG}:dest-fs=$destfs		$fsname
 	zfs set ${ZREPTAG}:dest-host=$desthost		$fsname
 	zfs set ${ZREPTAG}:savecount=$Z_SAVE_COUNT	$fsname
+	zfs set ${ZREPTAG}:orig-host=$Z_LOCAL_HOST	$fsname
 }
 
 
@@ -396,7 +397,8 @@ zrep_init(){
 		zrep_ssh $desthost zfs set ${ZREPTAG}:src-host=$Z_LOCAL_HOST $destfs
 		zrep_ssh $desthost zfs set ${ZREPTAG}:dest-fs=$destfs $destfs
 		zrep_ssh $desthost zfs set ${ZREPTAG}:dest-host=$desthost $destfs
-		zrep_ssh $desthost zfs set ${ZREPTAG}:savecount=$Z_SAVE_COUNT	$destfs
+		zrep_ssh $desthost zfs set ${ZREPTAG}:savecount=$Z_SAVE_COUNT $destfs
+		zrep_ssh $desthost zfs set ${ZREPTAG}:orig-host=$Z_LOCAL_HOST $destfs
 
 	fi
 

--- a/zrep_snap
+++ b/zrep_snap
@@ -211,7 +211,7 @@ _clear(){
 clearquit(){
 	remhost=`$ZFSGETVAL ${ZREPTAG}:dest-host $1`
 	remfs=`$ZFSGETVAL ${ZREPTAG}:dest-fs $1`
-	if [[ $? -eq 0 ]] && [[ "$remhost" != "" ]] && [[ "$remfs" != "" ]]; then
+	if [[ $? -eq 0 ]] && [[ "$remhost" != "-" ]] && [[ "$remfs" != "-" ]]; then
 		zrep_ssh $remhost zfs destroy -r $remfs
 	fi
 
@@ -296,7 +296,7 @@ zrep_init(){
 
 	#sanity checks
 	check="`$ZFSGETVAL ${ZREPTAG}:dest-fs $srcfs`"
-	if [[ "$check" != "" ]] ; then
+	if [[ "$check" != "-" ]] ; then
 		print "$srcfs is at least partially configured by zrep"
 		check="`$ZFSGETLVAL ${ZREPTAG}:master $srcfs`"
 		if [[ "$check" != "" ]] ; then

--- a/zrep_status
+++ b/zrep_status
@@ -102,7 +102,7 @@ list_verbose(){
 		# match these 'source' types. So "grep zrep:" is not
 		# neccessary. Although we may pick up other user-set values,
 		# but that is not neccessarily a bad thing
-	zfs get -H -o property,value -s $PROPTYPES all $1
+	zfs get -H -o property,value -s $PROPTYPES all $1 | sort
 	print "last snapshot synced: `getlastsnapsent $1`"
 
 }

--- a/zrep_sync
+++ b/zrep_sync
@@ -228,13 +228,20 @@ _sync(){
 
 	# other than zrep_init, this should be the ONLY place we do a send
 	#   Sigh. but now we also do in _refreshpull
+	#
+	# As a workaround for the "destination ... has been modified" problem, we are
+	# using 'zfs recv -F' in order to get a clean state on the receiving side. See:
+	# http://list.zfsonlinux.org/pipermail/zfs-discuss/2015-June/022565.html
+	# https://github.com/zfsonlinux/zfs/issues/3490
+	# This might be a ZFS on Linux only issue, though.
+	#
 	if [[ "$BBCP" != "" ]] ; then
 	        SENDCMD="zfs send ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap"
 		$BBCP -N io "$SENDCMD" \
-		   "$desthost:zfs recv $destfs"
+		   "$desthost:zfs recv -F $destfs"
 	else
 		eval zfs send ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap ${Z_F_OUT} | 
-		   zrep_ssh $desthost "${Z_F_IN} zfs recv $destfs"
+		   zrep_ssh $desthost "${Z_F_IN} zfs recv -F $destfs"
 	fi
 
 	# I rename this to _unsent rather than just delete, in case people are using zrep

--- a/zrep_sync
+++ b/zrep_sync
@@ -285,7 +285,7 @@ zrep_synconly(){
 
 	desthost=`$ZFSGETVAL ${ZREPTAG}:dest-host $srcfs`
 	destfs=`$ZFSGETVAL ${ZREPTAG}:dest-fs $srcfs`
-	if [[ $? -ne 0 ]] || [[ "$desthost" == "" ]] || [[ "$destfs" == "" ]];
+	if [[ $? -ne 0 ]] || [[ "$desthost" == "-" ]] || [[ "$destfs" == "-" ]];
 	then
 		zrep_errquit Problem getting zrep properties for fs $srcfs
 	fi
@@ -346,7 +346,7 @@ zrep_sync(){
 
 	desthost=`$ZFSGETVAL ${ZREPTAG}:dest-host $srcfs`
 	destfs=`$ZFSGETVAL ${ZREPTAG}:dest-fs $srcfs`
-	if [[ $? -ne 0 ]] || [[ "$desthost" == "" ]] || [[ "$destfs" == "" ]];
+	if [[ $? -ne 0 ]] || [[ "$desthost" == "-" ]] || [[ "$destfs" == "-" ]];
 	then
 		zrep_errquit Problem getting zrep properties for fs $srcfs
 	fi

--- a/zrep_vars
+++ b/zrep_vars
@@ -73,6 +73,13 @@ ZREPTAG=${ZREPTAG:-zrep}
 # If you dont have /usr/perl5, this wont hurt you so just ignore it.
 PERL_BIN=${PERL_BIN:-/usr/perl5/bin}
 
+# If you wish to add a suffix to the detected local hostname, add it here.
+# This is especially useful if you want to run the replication over a
+# second network interface with possibly even a dedicated switch.
+# You could then use a separate local subnet and add e.g. all hostnames
+# with an "-int" suffix to DNS.
+#Z_LOCAL_HOST_SUFFIX=-int
+
 
 
 #########################################################################
@@ -111,6 +118,7 @@ if [[ "$ZREP_SRC_HOST" != "" ]] ; then
 else
 	Z_LOCAL_HOST=`uname -n`
 	Z_LOCAL_HOST=${Z_LOCAL_HOST%%.*}
+	Z_LOCAL_HOST="${Z_LOCAL_HOST}${Z_LOCAL_HOST_SUFFIX:}"
 fi
 
 if [[ "$ZREP_R" == "-R" ]] ; then


### PR DESCRIPTION
Two more aggressive lines where the `received` property on the remote host did not get respected. Thanks for fixing!