### PR TITLE
Added missing date fallback

### DIFF
--- a/zrep
+++ b/zrep
@@ -539,7 +539,11 @@ zrep_status(){
 		else
 			if (( Z_HAS_SNAPPROPS )) ; then
 			typeset sentseconds=`zfs get -H -o value ${ZREPTAG}:sent $lastsnap`
-			date=`perl -e 'use POSIX qw(strftime); print strftime "%Y/%m/%d-%H:%M:%S",localtime('$sentseconds');' `
+			date=`perl -e 'use POSIX qw(strftime); print strftime "%Y/%m/%d-%H:%M:%S",localtime('$sentseconds');' 2>/dev/null`
+			if [[ -z "$date" ]] ; then
+				# attempt fallback if no perl present (eg: stock FreeBSD)
+				date=`date +%Y/%m/%d-%H:%M:%S`
+			fi
 			vdate=${date%:*}
 
 			else


### PR DESCRIPTION
Hi, I've added some missing date fallback code, this fix removes completely the need for perl under FreeBSD:

```
xigmanas: ~# zrep status
/usr/local/bin/zrep[542]: perl: not found [No such file or directory]
data1/mydata                                   last synced 
xigmanas: ~# zrep status
data1/mydata                                   last synced 2018/09/08-22:08:35 <--- Fixed
xigmanas: ~#
```

Thanks for this top notch ZFS replication utility.
Best regards.