### PR TITLE
Modified locking to avoid the use of /proc

### DIFF
--- a/zrep
+++ b/zrep
@@ -253,7 +253,7 @@ Z_SETHOLD=${Z_SETHOLD:-"zfs hold"}
 
 # return PID of proc holding global lock, or nothing
 zrep_global_lock_pid(){
-	$LS -l $Z_GLOBAL_LOCKFILE 2>/dev/null |awk -F/ '{print $NF}'
+	cat $Z_GLOBAL_LOCKFILE 2>/dev/null
 }
 
 # return 0 if "we" are holding lock, 1 otherwise
@@ -282,9 +282,8 @@ zrep_get_global_lock(){
 	typeset lockpid
 
 
-	[[ -d /proc/$$ ]] || zrep_errquit "/proc fs must be functional to use zrep"
+	(set -C; echo $Z_GLOBAL_PID > $Z_GLOBAL_LOCKFILE) && return 0
 
-	$LN_S /proc/$Z_GLOBAL_PID $Z_GLOBAL_LOCKFILE && return 0
 
 	# otherwise, deal with fail
 	# Careful of race conditions on stale CLEAN UP!
@@ -298,10 +297,11 @@ zrep_get_global_lock(){
 	# For now, must request manual cleanup
 	while (( retry_count > 0 )); do
 		sleep 1
-		$LN_S /proc/$Z_GLOBAL_PID $Z_GLOBAL_LOCKFILE && return 0
+		(set -C; echo $Z_GLOBAL_PID > $Z_GLOBAL_LOCKFILE) && return 0
 		retry_count=$((retry_count-1))
 		lockpid=`zrep_global_lock_pid`
-		if [[ ! -d /proc/$lockpid ]] ; then
+		echo kill -0 $lockpid
+		if ! kill -0 $lockpid; then
 			_errprint ERROR: stale global lock file
 			_errprint ERROR: shut down ALL zrep instances, then manually remove
 			_errprint $Z_GLOBAL_LOCKFILE

--- a/zrep_vars
+++ b/zrep_vars
@@ -247,7 +247,7 @@ Z_SETHOLD=${Z_SETHOLD:-"zfs hold"}
 
 # return PID of proc holding global lock, or nothing
 zrep_global_lock_pid(){
-	$LS -l $Z_GLOBAL_LOCKFILE 2>/dev/null |awk -F/ '{print $NF}'
+	cat $Z_GLOBAL_LOCKFILE 2>/dev/null
 }
 
 # return 0 if "we" are holding lock, 1 otherwise
@@ -276,9 +276,8 @@ zrep_get_global_lock(){
 	typeset lockpid
 
 
-	[[ -d /proc/$$ ]] || zrep_errquit "/proc fs must be functional to use zrep"
+	(set -C; echo $Z_GLOBAL_PID > $Z_GLOBAL_LOCKFILE) && return 0
 
-	$LN_S /proc/$Z_GLOBAL_PID $Z_GLOBAL_LOCKFILE && return 0
 
 	# otherwise, deal with fail
 	# Careful of race conditions on stale CLEAN UP!
@@ -292,10 +291,10 @@ zrep_get_global_lock(){
 	# For now, must request manual cleanup
 	while (( retry_count > 0 )); do
 		sleep 1
-		$LN_S /proc/$Z_GLOBAL_PID $Z_GLOBAL_LOCKFILE && return 0
+		(set -C; echo $Z_GLOBAL_PID > $Z_GLOBAL_LOCKFILE) && return 0
 		retry_count=$((retry_count-1))
 		lockpid=`zrep_global_lock_pid`
-		if [[ ! -d /proc/$lockpid ]] ; then
+		if ! kill -0 $lockpid; then
 			_errprint ERROR: stale global lock file
 			_errprint ERROR: shut down ALL zrep instances, then manually remove
 			_errprint $Z_GLOBAL_LOCKFILE


### PR DESCRIPTION
This PR addresses issue #100. I'm testing now.

Locking is now done with a combination of two things:
- `kill 0 $pid` to determine if the given process id is running, and
- `(set -C; echo $Z_GLOBAL_PID > $Z_GLOBAL_LOCKFILE)` to create the lock file. File creation is generally an atomic process, and with the noclobber option set, if the file already exists, then this fails. (Probably using the same `open` under the hood as `ls` uses).