### PR TITLE
Verbose output on zfs send calls to show progress

### DIFF
--- a/zrep
+++ b/zrep
@@ -79,6 +79,8 @@ ZREPTAG=${ZREPTAG:-zrep}
 # If you dont have /usr/perl5, this wont hurt you so just ignore it.
 PERL_BIN=${PERL_BIN:-/usr/perl5/bin}
 
+# Verbose output when zfs send is done (shows progress)
+#ZREP_SEND_VERBOSE=-v
 
 # Hidden var, that isnt really meant to be used directly.
 # It gets set if you use "zrep sync -c". 

--- a/zrep_snap
+++ b/zrep_snap
@@ -368,10 +368,10 @@ zrep_init(){
 		#
 
 		if [[ "$BBCP" != "" ]] ; then
-		$BBCP -N io "zfs send ${ZREP_R} -p $snap" \
+		$BBCP -N io "zfs send ${ZREP_SEND_VERBOSE} ${ZREP_R} -p $snap" \
 		    "$desthost:zfs recv -u  $READONLYPROP -F $destfs"
 		else
-		eval zfs send ${ZREP_R} -p $snap ${Z_F_OUT}|
+		eval zfs send ${ZREP_SEND_VERBOSE} ${ZREP_R} -p $snap ${Z_F_OUT}|
 			zrep_ssh $desthost "${Z_F_IN} zfs recv -u $READONLYPROP -F $destfs"
 		fi
 	else
@@ -384,10 +384,10 @@ zrep_init(){
 		#  Update your system! :p )
 		#
 		if [[ "$BBCP" != "" ]] ; then
-		$BBCP -N io "zfs send ${ZREP_R} $snap" \
+		$BBCP -N io "zfs send ${ZREP_SEND_VERBOSE} ${ZREP_R} $snap" \
 		    "$desthost:zfs recv $READONLYPROP -F $destfs"
 		else
-		eval zfs send ${ZREP_R} $snap ${Z_F_OUT}|
+		eval zfs send ${ZREP_SEND_VERBOSE} ${ZREP_R} $snap ${Z_F_OUT}|
 		  zrep_ssh $desthost "${Z_F_IN} zfs recv $READONLYPROP -F $destfs"
 		fi
 	fi

--- a/zrep_sync
+++ b/zrep_sync
@@ -286,11 +286,11 @@ _sync(){
 	# other than zrep_init, this should be the ONLY place we do a send
 	#   Sigh. but now we also do in _refreshpull
 	if [[ "$BBCP" != "" ]] ; then
-	        SENDCMD="zfs send ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap"
+	        SENDCMD="zfs send ${ZREP_SEND_VERBOSE} ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap"
 		$BBCP -N io "$SENDCMD" \
 		   "$desthost:zfs recv $force $destfs"
 	else
-		eval zfs send ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap ${Z_F_OUT} | 
+		eval zfs send ${ZREP_SEND_VERBOSE} ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $newsnap ${Z_F_OUT} | 
 		   zrep_ssh $desthost "${Z_F_IN} zfs recv $force $destfs"
 	fi
 
@@ -611,7 +611,7 @@ _refreshpull(){
 		zrep_errquit Error: we currently only support modern ZFS that allows setting props on snaps
 	fi
 
-	zfs send ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $latest
+	zfs send ${ZREP_SEND_VERBOSE} ${ZREP_R} ${ZREP_INC_FLAG} $lastsent $latest
 
 	if [[ $? -ne 0 ]] ; then
 		zrep_errquit Some kind of error during sending. Bailing out of _refreshpull


### PR DESCRIPTION
Hello!

I added the -v switch to all zfs send commands to show the progress of the send process.
It's very usefull to see whats going on.

Greets
Matthias