### PR TITLE
Ensure fs and date string are separated

### DIFF
--- a/zrep
+++ b/zrep
@@ -592,7 +592,7 @@ zrep_status(){
 			printf "%-25s->%-35s %s\n" $srcfs "$desthost:$destfs" "$vdate"
 		else
 			printf "%-47s" $srcfs
-			print "last synced $date"
+			print " last synced $date"
 		fi
 		shift
 	done

--- a/zrep_status
+++ b/zrep_status
@@ -71,7 +71,7 @@ zrep_status(){
 			printf "%-25s->%-35s %s\n" $srcfs "$desthost:$destfs" "$vdate"
 		else
 			printf "%-47s" $srcfs
-			print "last synced $date"
+			print " last synced $date"
 		fi
 		shift
 	done


### PR DESCRIPTION
We're using zrep in an automated fashion and parse its output. Unfortunately we tend to have some long paths, thus clashing together the filesystem string and "last synced".