### PR TITLE
Fix "Warning: zfs recv lacking -o readonly"

### DIFF
--- a/zrep
+++ b/zrep
@@ -242,8 +242,8 @@ else
 	# SmartOS and FreeBSD implemented recv -o WRONG! So no Z_HAS_REC_O for it!
 	# But also, -o doesnt even show in the output of solaris zfs usage. sigh.
 	# So have to be creative
-	if grep 'create .* -o prop' $zrep_checkfile >/dev/null ;then
-		grep 'rec.* -o origin' $zrep_checkfile >/dev/null  ||
+	if grep 'create .*-o prop' $zrep_checkfile >/dev/null ;then
+		grep 'rec.*-o origin' $zrep_checkfile >/dev/null  ||
 		     Z_HAS_REC_O=1 # can use recv -o
 	fi
 	if grep 'set .*snapshot' $zrep_checkfile >/dev/null ;then


### PR DESCRIPTION
For OpenZFS 0.7.12 on Debian 10 with ksh v93, running a `zrep init` for a dataset failed to set `readonly=on` on the dest host. Removing the space between `.*` and `-o` in `if grep 'create .* -o prop' $zrep_checkfile` (line 245) fixed this problem.

I assume the conditional that follows (`grep 'rec.* -o origin`) has the same issue, so I removed the space there as well (OpenZFS 0.7.12 on Debian 10 doesn't show support for `-o origin` in the `zfs` command usage, so the change doesn't have an impact on my system)