### PR TITLE
Recognize receive|recv output for -u detection

### DIFF
--- a/zrep_vars
+++ b/zrep_vars
@@ -264,7 +264,7 @@ else
 	if grep 'receive[ |].*-[a-zA-Z]*x' $zrep_checkfile >/dev/null ;then
 		Z_HAS_X=1	  # can use recv -x
 	fi
-	if grep 'receive .*-[a-zA-Z]*u' $zrep_checkfile >/dev/null ;then
+	if grep 'receive[ |].*-[a-zA-Z]*u' $zrep_checkfile >/dev/null ;then
 		Z_HAS_REC_U=1	  # can use recv -u
 	fi
 	# This bit is unfortunately ugly. Two problems:


### PR DESCRIPTION
zfs help output on FreeBSD 11.2-STABLE:

	receive|recv [-vnsFu] <filesystem|volume|snapshot>
	receive|recv [-vnsFu] [-o origin=<snapshot>] [-d | -e] <filesystem>
	receive|recv -A <filesystem|volume>

we should detect -u in the same way we try it for -x