### PR TITLE
auto-apply --raw send flag (ZREP_SEND_FLAGS) on encrypted datasets

### DIFF
--- a/zrep
+++ b/zrep
@@ -1314,6 +1314,13 @@ zrep_init(){
 		print Creating snapshot $snap
 		zfs snapshot $Z_SNAP_R $snap || clearquit $srcfs "Cannot create initial snapshot $snap"
 
+		# Set --raw zfs send flag for encrypted filesystem, if 
+		# $ZREP_SEND_FLAGS was not already defined.
+		encryption=`$ZFSGETVAL encryption $srcfs`
+		if [[ "$encryption" != "off" ]]; then
+			ZREP_SEND_FLAGS=${ZREP_SEND_FLAGS:---raw}
+		fi
+
 		# Note that we may not want to use -p for normal zrep syncs
 		# We also should not use -F for normal recv. See workflow.txt
 		# Note: we may have to reset readonly=on, if we used -p on send...
@@ -1745,6 +1752,13 @@ _sync(){
 	if [[ "$ZREP_RESUME" != "" ]] ; then
 		token=`zrep_ssh $desthost $ZFSGETVAL receive_resume_token $destfs`
 		if [[ "$token" == "-" ]] ; then token="" ; fi
+	fi
+
+	# Always set --raw zfs send flag for encrypted filesystem, if 
+	# $ZREP_SEND_FLAGS was not already defined.
+	encryption=`$ZFSGETVAL encryption $srcfs`
+	if [[ "$encryption" != "off" ]]; then
+		ZREP_SEND_FLAGS=${ZREP_SEND_FLAGS:---raw}
 	fi
 
 	# Note: doing "-o $senttimeprop" sets prop on FILESYSTEM, not snap.

--- a/zrep_snap
+++ b/zrep_snap
@@ -469,6 +469,13 @@ zrep_init(){
 		print Creating snapshot $snap
 		zfs snapshot $Z_SNAP_R $snap || clearquit $srcfs "Cannot create initial snapshot $snap"
 
+		# Set --raw zfs send flag for encrypted filesystem, if 
+		# $ZREP_SEND_FLAGS was not already defined.
+		encryption=`$ZFSGETVAL encryption $srcfs`
+		if [[ "$encryption" != "off" ]]; then
+			ZREP_SEND_FLAGS=${ZREP_SEND_FLAGS:---raw}
+		fi
+
 		# Note that we may not want to use -p for normal zrep syncs
 		# We also should not use -F for normal recv. See workflow.txt
 		# Note: we may have to reset readonly=on, if we used -p on send...

--- a/zrep_sync
+++ b/zrep_sync
@@ -304,6 +304,13 @@ _sync(){
 		if [[ "$token" == "-" ]] ; then token="" ; fi
 	fi
 
+	# Always set --raw zfs send flag for encrypted filesystem, if 
+	# $ZREP_SEND_FLAGS was not already defined.
+	encryption=`$ZFSGETVAL encryption $srcfs`
+	if [[ "$encryption" != "off" ]]; then
+		ZREP_SEND_FLAGS=${ZREP_SEND_FLAGS:---raw}
+	fi
+
 	# Note: doing "-o $senttimeprop" sets prop on FILESYSTEM, not snap.
 	# So we dont do that usually
 


### PR DESCRIPTION
We need some auto-detection of encrypted zfs datasets so that `--raw` zfs send flag is added without having to explicitly set `ZREP_SEND_FLAGS` environment variable. As we usually want to replicate all datasets managed by zrep using `zrep sync -f all`, we could not use different `ZREP_SEND_FLAGS` (with or without `--raw`) for individual datasets.

To be on the safe side, this patch only sets `ZREP_SEND_FLAGS=--raw` if the environment variable was not defined / was empty.