### PR TITLE
defaults file sourcing

### DIFF
--- a/zrep_vars
+++ b/zrep_vars
@@ -4,6 +4,11 @@
 # It contains all 'constant' definitions, as well as a few crucial
 # shared routines, such as lock handling ones.
 
+# Global defaults file
+if [[ -f "/etc/default/zrep" ]]; then
+  . /etc/default/zrep
+fi
+
 ########################################################################
 # User tunable section. These may be overridden in user environment vars
 SSH=${SSH:-ssh}


### PR DESCRIPTION
This PR adds sourcing a file from /etc/default/zrep to set any variable within zrep. Doing so allows managing defaults using any orchestration software without the need to touch zrep itself. If the file is not present it's ignored.