### PR TITLE
actually ignore $Z_GLOBAL_LOCKFILE existing

### DIFF
--- a/zrep
+++ b/zrep
@@ -398,7 +398,7 @@ zrep_get_global_lock(){
 
 	set -C  #noclobber
 	# ignore error this time, because we retry anyway.
-	echo $Z_GLOBAL_PID > $Z_GLOBAL_LOCKFILE 2>/dev/null && return 0  
+	[ ! -e $Z_GLOBAL_LOCKFILE ] && echo $Z_GLOBAL_PID > $Z_GLOBAL_LOCKFILE && return 0  
 
 	# Otherwise, deal with fail/retry.
 	# Careful of race conditions on stale CLEAN UP!


### PR DESCRIPTION
existing implementation outputs `/usr/local/bin/zrep[401]: /var/run/zrep.lock: file already exists [File exists]` if `/var/run/zrep.lock` is already there before sleeping/retry, and since we're retrying anyway there's no point in doing that