### PR TITLE
correcting lastsnapsent when resuming broken sending

### DIFF
--- a/zrep_snap
+++ b/zrep_snap
@@ -52,8 +52,10 @@ getlastsnapsent(){
 	# arg.  more efficient if we can just return value directly,
 	# but i'm using backwards compat :(
 	typeset lastsent
-	lastsent=`zfs get  -H -o name -r -s local ${ZREPTAG}:sent $1 |
-	   sort | tail -1`
+        # BASSILOV 2020-10-18 sorting by name is not good way because the last sent snap can be not from zrep (when resuming sendings for example)
+        ## lastsent=`zfs get  -H -o name -r -s local ${ZREPTAG}:sent $1 |
+        ##   sort | tail -1`
+        lastsent=`zfs get -H -o value,name -r -s local ${ZREPTAG}:sent $1 | sort -n | tail -1 | awk '{print $2;}'`
 	if [[ "$lastsent" != "" ]] ; then
 		print $lastsent
 		return

--- a/zrep_sync
+++ b/zrep_sync
@@ -320,6 +320,13 @@ _sync(){
 		   "$desthost:zfs recv $recv_s $force $destfs"
 	else
 		if [[ "$token" != "" ]] ; then
+                        # BASSILOV 2020-10-18 when resuming broken sending the last succesful snap will be different than the defined previously
+			# so we must find the correct one to set zrep:sent property on success. getlastsnapsent should also be fixed to find sync snaps not matching zrep_###### mask
+			# TO DO this option will not work correctly when used with ZREP_R=-R because it resumes only part of recursive send
+			# on my system I made additional property zrep:canresume and a script which analizes it and launch zrep with -s parameter when set
+                        newsnap=`zfs send ${ZREP_RESUME_FLAGS} -n -v -t $token | grep 'toname = ' | awk 'BEGIN{ FS=" = "; }{ print $2; }'`
+                        snapname=${newsnap#*@}
+		
 			eval zfs send ${ZREP_RESUME_FLAGS} -t $token  ${Z_F_OUT} | 
 			   zrep_ssh $desthost "${Z_F_IN} zfs recv $recv_s $force $destfs"
 		else


### PR DESCRIPTION
When resuming broken sending the last succesful snap will be different than the one made for sync if there are intermediate snaps and the sync process was interrupted while sending not zrep snap. 
So my patch fixes it.
It does not fix the problem when sync process was interrupted during sending nested zfs.
I use -s option only for single zfs