### PR TITLE
Allow `-R` to be passed *after* other global flags (`-t` and `-D`)

### DIFF
--- a/zrep
+++ b/zrep
@@ -228,22 +228,6 @@ else
 	Z_LOCAL_HOST=${Z_LOCAL_HOST%%.*}
 fi
 
-
-# Slightly ugly to implement this as a global flag. But... it makes 
-# a lot of things simpler, like "ssh zrep xyhz" for multiple things.
-if [[ "$1" == "-R" ]] ; then
-	ZREP_R="-R"
-	shift
-fi
-
-if [[ "$ZREP_R" == "-R" ]] ; then
-	# ZREP_R is a user-settable env var. It also gets used in
-	# "zfs send"  commandlines.  However.. we also need to call
-	# "zfs snap".. which requires LOWERCASE R. So this is an automatically set
-	# mirror of that.
-	Z_SNAP_R="-r"
-fi
-
 if [[ "$MBUFFER" != "" ]] ; then
 	_errprint WARNING: MBUFER variable deprecated in zrep
 	_errprint WARNING: use ZREP_OUTFILTER and ZREP_INFILTER instead
@@ -2677,7 +2661,7 @@ usage(){
 #
 # Special global flags that must always be processed FIRST, before normal command args.
 #
-while [[ "$1" == -[tD] ]] ; do
+while [[ "$1" == -[tDR] ]] ; do
 	case "$1" in
 	    -D)
 		DEBUG=1
@@ -2692,8 +2676,12 @@ while [[ "$1" == -[tD] ]] ; do
 		shift
 		shift
 		;;
+		-R)
+		ZREP_R="-R"
+		shift
+		;;
 	esac
-done	
+done
 
 
 if [[ "$ZREPTAG" != "zrep" ]] ; then
@@ -2708,6 +2696,13 @@ fi
 # ensure it is set to SOMETHING by default. Default is to send all
 ZREP_INC_FLAG=${ZREP_INC_FLAG:-"-I"}
 
+if [[ "$ZREP_R" == "-R" ]] ; then
+	# ZREP_R is a user-settable env var. It also gets used in
+	# "zfs send"  commandlines.  However.. we also need to call
+	# "zfs snap".. which requires LOWERCASE R. So this is an automatically set
+	# mirror of that.
+	Z_SNAP_R="-r"
+fi
 
 
 

--- a/zrep_top
+++ b/zrep_top
@@ -66,7 +66,7 @@ usage(){
 #
 # Special global flags that must always be processed FIRST, before normal command args.
 #
-while [[ "$1" == -[tD] ]] ; do
+while [[ "$1" == -[tDR] ]] ; do
 	case "$1" in
 	    -D)
 		DEBUG=1
@@ -81,8 +81,12 @@ while [[ "$1" == -[tD] ]] ; do
 		shift
 		shift
 		;;
+		-R)
+		ZREP_R="-R"
+		shift
+		;;
 	esac
-done	
+done
 
 
 if [[ "$ZREPTAG" != "zrep" ]] ; then
@@ -97,6 +101,13 @@ fi
 # ensure it is set to SOMETHING by default. Default is to send all
 ZREP_INC_FLAG=${ZREP_INC_FLAG:-"-I"}
 
+if [[ "$ZREP_R" == "-R" ]] ; then
+	# ZREP_R is a user-settable env var. It also gets used in
+	# "zfs send"  commandlines.  However.. we also need to call
+	# "zfs snap".. which requires LOWERCASE R. So this is an automatically set
+	# mirror of that.
+	Z_SNAP_R="-r"
+fi
 
 
 

--- a/zrep_vars
+++ b/zrep_vars
@@ -218,22 +218,6 @@ else
 	Z_LOCAL_HOST=${Z_LOCAL_HOST%%.*}
 fi
 
-
-# Slightly ugly to implement this as a global flag. But... it makes 
-# a lot of things simpler, like "ssh zrep xyhz" for multiple things.
-if [[ "$1" == "-R" ]] ; then
-	ZREP_R="-R"
-	shift
-fi
-
-if [[ "$ZREP_R" == "-R" ]] ; then
-	# ZREP_R is a user-settable env var. It also gets used in
-	# "zfs send"  commandlines.  However.. we also need to call
-	# "zfs snap".. which requires LOWERCASE R. So this is an automatically set
-	# mirror of that.
-	Z_SNAP_R="-r"
-fi
-
 if [[ "$MBUFFER" != "" ]] ; then
 	_errprint WARNING: MBUFER variable deprecated in zrep
 	_errprint WARNING: use ZREP_OUTFILTER and ZREP_INFILTER instead


### PR DESCRIPTION
Using custom tags and a recursive `refresh` fails when creating snapshot with error:

    ERROR: unrecognized zrep subcommand -R

This is because it executes something like

    ssh  source_host zrep -t zrep_tag -R snaponly fs

The `-R` flag comes after `-t` flag. However, `zrep` (prior this commit) required `-R` to be the fist flag.

This commit moves the check for `-R` flag and initialization of `ZREP_R` to the same loop that checks for other global flags (currently `-t` and `-D`). This fixes the issue.