### PR TITLE
Fix propagation of `ZREP_INC_FLAG` when doing `zrep refresh`

### DIFF
--- a/zrep
+++ b/zrep
@@ -2139,10 +2139,10 @@ zrep_refresh(){
 	fi
 
 	if [[ "$BBCP" != "" ]] ; then
-		$BBCP -N io "$srchost:$ZREP_PATH _refreshpull $newsnap $token" \
+		$BBCP -N io "$srchost:$ZREP_PATH ${ZREP_R} _refreshpull ${ZREP_INC_FLAG} $newsnap $token" \
 		  "zfs recv $force $destfs"
 	else
-		zrep_ssh $srchost "$ZREP_PATH ${ZREP_R} _refreshpull $newsnap $token ${Z_F_OUT}" |
+		zrep_ssh $srchost "$ZREP_PATH ${ZREP_R} _refreshpull ${ZREP_INC_FLAG} $newsnap $token ${Z_F_OUT}" |
 		  eval ${Z_F_IN} zfs recv $force $destfs
 	fi
 	if [[ $? -ne 0 ]] ; then
@@ -2184,6 +2184,13 @@ zrep_refresh(){
 _refreshpull(){
 	typeset fs snapname lastsent latest verbose
 	typeset token=""
+
+	case "$1" in
+		-i|-I)
+		ZREP_INC_FLAG=$1
+		shift
+		;;
+	esac
 
 	if [[ "$2" != "" ]] ; then
 		token="$2"

--- a/zrep_sync
+++ b/zrep_sync
@@ -617,10 +617,10 @@ zrep_refresh(){
 	fi
 
 	if [[ "$BBCP" != "" ]] ; then
-		$BBCP -N io "$srchost:$ZREP_PATH _refreshpull $newsnap $token" \
+		$BBCP -N io "$srchost:$ZREP_PATH ${ZREP_R} _refreshpull ${ZREP_INC_FLAG} $newsnap $token" \
 		  "zfs recv $force $destfs"
 	else
-		zrep_ssh $srchost "$ZREP_PATH ${ZREP_R} _refreshpull $newsnap $token ${Z_F_OUT}" |
+		zrep_ssh $srchost "$ZREP_PATH ${ZREP_R} _refreshpull ${ZREP_INC_FLAG} $newsnap $token ${Z_F_OUT}" |
 		  eval ${Z_F_IN} zfs recv $force $destfs
 	fi
 	if [[ $? -ne 0 ]] ; then
@@ -662,6 +662,13 @@ zrep_refresh(){
 _refreshpull(){
 	typeset fs snapname lastsent latest verbose
 	typeset token=""
+
+	case "$1" in
+		-i|-I)
+		ZREP_INC_FLAG=$1
+		shift
+		;;
+	esac
 
 	if [[ "$2" != "" ]] ; then
 		token="$2"


### PR DESCRIPTION
When doing `zrep refresh`, `ZREP_INC_FLAG` setting (on "refreshing" side) was (prior this commit) ignored, falling back to default setting.

This is because the value `ZREP_INC_FLAG` was not propagated to the other ("sending") side. One way would be to set it in `/etc/default/zrep` on the "sending" side - but this is both fiddly and sets it for all (that is, you cannot have one "refreshing" site using `-i` and the other using `-I`)

Better solution is to simply propagate the setting to the other side, which is what this commit does.